### PR TITLE
chore: git commit message template 추가

### DIFF
--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -1,0 +1,23 @@
+# -------------------------------
+# Git Commit Message Template
+# -------------------------------
+# 1. 제목(Title)은 50자 이하로 작성
+# 2. 본문(Body)은 72자 단위로 줄바꿈
+# 3. 타입(Type) 예시: feat, fix, docs, style, refactor, test, chore
+# 4. scope(선택사항): 영향을 받는 모듈/범위
+# 5. footer(선택사항): 관련 이슈, BREAKING CHANGE
+# -------------------------------
+
+<type>(<scope>): <subject>
+# - type: feat, fix, docs, style, refactor, test, chore
+# - scope: 영향을 받는 범위(선택)
+# - subject: 간결한 한 줄 요약
+
+<body>
+# - 상세 변경 사항 설명
+# - 변경 이유 작성
+# - 필요한 경우 여러 줄로 작성 가능
+
+<footer>
+# - 관련 이슈 번호: ex) Closes #123
+# - BREAKING CHANGE: 기존 동작에 영향을 주는 변경


### PR DESCRIPTION
- 표준화된 커밋 메시지 형식 제공을 위해 gitmessage.txt 파일 추가
- type, scope, subject, body, footer 등의 가이드라인을 주석으로 작성